### PR TITLE
Add default sizes to the nodes to work with ZoomToFit

### DIFF
--- a/docs/Layouts/Pages/Index.razor
+++ b/docs/Layouts/Pages/Index.razor
@@ -74,7 +74,7 @@ or it will not be rendered.
 
     private static NodeModel NewNode(double x, double y)
     {
-        var node = new NodeModel(Guid.NewGuid().ToString(), new Point(x, y));
+        var node = new NodeModel(Guid.NewGuid().ToString(), new Point(x, y)) { Size = new Size(100,100) };
         return node;
     }
 


### PR DESCRIPTION

As the nodes did not have sizes, ZoomToFit behaved erroneously as the GetBounds method returned ♾ for its width & height elements. This is subtle, and super-confusing, so to avoid someone else having this future pain, I've updated the Layout demo code to provide some default sizes that match the default expectations in the layout code. 

This means the demo can be simply extended to include a ZoomToFit call with no ill effects